### PR TITLE
parsing numbers to string, setup will install requests 2.3.0, added link...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+default: compile
+all: compile
+compile:
+	python -c "from py_compile import compile; compile('libest.py')"
+
+clean:
+	rm *.pyc

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ est_upload
 
 A python library to communicate with Exercise Submission Tool (https://est.informatik.uni-erlangen.de).
 
+If you are searching the console interface, look at [jneureuther/est](https://github.com/jneureuther/est).
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download the latest release from https://pypi.python.org/pypi/est_upload/ or sim
 Dependencies
 ------------
 
-* python-requests
+* python-requests (2.3.0)
 * python-bs4
 * python-magic
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-est_upload
-==========
+libest
+======
 
 A python library to communicate with Exercise Submission Tool (https://est.informatik.uni-erlangen.de).
 
@@ -8,7 +8,7 @@ If you are searching the console interface, look at [jneureuther/est](https://gi
 Installation
 ------------
 
-Download the latest release from https://pypi.python.org/pypi/est_upload/ or simply run `pip install est_upload`
+Download the latest release from https://pypi.python.org/pypi/libest/ or simply run `pip install libest`
 
 Dependencies
 ------------

--- a/est_upload.py
+++ b/est_upload.py
@@ -28,7 +28,7 @@ class ESTUpload:
             return True if est_error is None else est_error.next.strip()
 
     def search_file(self, name, lecture_id):
-        est_file_id_tag = self.parse_html_text(self.s.get(self.base_url + '/encodingchecker.html?lectureId=' + lecture_id
+        est_file_id_tag = self.parse_html_text(self.s.get(self.base_url + '/encodingchecker.html?lectureId=' + str(lecture_id)
                                                           + '&action=submit&tab=upload').text, name, "label")
         if est_file_id_tag is None:
             return 2
@@ -45,7 +45,7 @@ class ESTUpload:
             return 3
 
         file = [(est_file_id, (name, open(path, 'rb'), mime_type))]
-        params = {'upload': 'upload', 'lectureId': lecture_id,
+        params = {'upload': 'upload', 'lectureId': str(lecture_id),
                   'submitterCode_' + est_file_id[:4]: submission_member_code, 'action': 'submit', 'tab': 'upload'}
         est_error = self.parse_html_id(self.s.post(self.base_url + '/encodingchecker.html', files=file, data=params)
                                        .text, 'estError')
@@ -56,7 +56,7 @@ class ESTUpload:
 
     def check_file(self, name, path, lecture_id):
         file_url = self.base_url + '/' + self.parse_html_text(self.s.get(self.base_url + '/judging.html?lectureId=' +
-                                                                         lecture_id + '&action=submit&tab=overview')
+                                                                         str(lecture_id) + '&action=submit&tab=overview')
                                                               .text, name, "td").find_next("a").get('href')
         temp_file_path = "/tmp/" + name
         self.download_file(file_url, temp_file_path)
@@ -67,7 +67,7 @@ class ESTUpload:
 
     def check_status(self, name, lecture_id):
         name_tag = self.parse_html_text(self.s.get(self.base_url + '/judging.html?lectureId=' +
-                                                   lecture_id + '&action=submit&tab=overview').text, name, "td")
+                                                   str(lecture_id) + '&action=submit&tab=overview').text, name, "td")
         if name_tag is not None:
             return name_tag.find_previous("span").get('title')
 
@@ -101,7 +101,7 @@ class ESTUpload:
         return True if __est_version__ in est_version else est_version
 
     def get_submission_with(self, group_submission_code, lecture_id):
-        return self.parse_html_text(self.s.get(self.base_url + '/submissiongroupdynamic.html?lectureId=' + lecture_id +
+        return self.parse_html_text(self.s.get(self.base_url + '/submissiongroupdynamic.html?lectureId=' + str(lecture_id) +
                                                '&action=submit&tab=overview')
                                     .text, group_submission_code, "span").previous_element
 

--- a/est_upload.py
+++ b/est_upload.py
@@ -21,20 +21,24 @@ class ESTUpload:
     def __del__(self):
         self.s.close()
 
+    # login to est
+    # returns True if successfully logged in
     def authenticate(self, user, passwd):
             params = {'login': user, 'password': passwd, 'submit': 'login'}
             est_error = self.parse_html_id(self.s.post(self.base_url + '/login.html?action=student',
                                                        params=params).text, 'estError')
             return True if est_error is None else est_error.next.strip()
 
-    def search_file(self, name, lecture_id):
-        est_file_id_tag = self.parse_html_text(self.s.get(self.base_url + '/encodingchecker.html?lectureId=' + str(lecture_id)
-                                                          + '&action=submit&tab=upload').text, name, "label")
+    # returns the file id of the file name. If it not exists, it returns 2
+    def search_file(self, file_name, lecture_id):
+        est_file_id_tag = self.parse_html_text(self.s.get(self.base_url + '/encodingchecker.html?lectureId='
+                                                                        + str(lecture_id) + '&action=submit&tab=upload').text, file_name, "label")
         if est_file_id_tag is None:
             return 2
         else:
             return est_file_id_tag['for']
 
+    # submits a file to est
     def submit_file(self, name, path, lecture_id, submission_member_code):
         est_file_id = self.search_file(name, lecture_id)
         if est_file_id is 2:
@@ -44,16 +48,17 @@ class ESTUpload:
         if mime_type == 'inode/x-empty':
             return 3
 
-        file = [(est_file_id, (name, open(path, 'rb'), mime_type))]
+        loc_file = [(est_file_id, (name, open(path, 'rb'), mime_type))]
         params = {'upload': 'upload', 'lectureId': str(lecture_id),
                   'submitterCode_' + est_file_id[:4]: submission_member_code, 'action': 'submit', 'tab': 'upload'}
-        est_error = self.parse_html_id(self.s.post(self.base_url + '/encodingchecker.html', files=file, data=params)
+        est_error = self.parse_html_id(self.s.post(self.base_url + '/encodingchecker.html', files=loc_file, data=params)
                                        .text, 'estError')
         if est_error is None:
             return 1
         else:
             return est_error.next.strip()
 
+    # checks, if the given file is the same like in est
     def check_file(self, name, path, lecture_id):
         file_url = self.base_url + '/' + self.parse_html_text(self.s.get(self.base_url + '/judging.html?lectureId=' +
                                                                          str(lecture_id) + '&action=submit&tab=overview')
@@ -65,12 +70,14 @@ class ESTUpload:
         else:
             return 0
 
+    # returns the status of a file on est
     def check_status(self, name, lecture_id):
         name_tag = self.parse_html_text(self.s.get(self.base_url + '/judging.html?lectureId=' +
                                                    str(lecture_id) + '&action=submit&tab=overview').text, name, "td")
         if name_tag is not None:
             return name_tag.find_previous("span").get('title')
 
+    # downloads a file from est to path
     def download_file(self, url, path):
         # local_filename = url.split('/')[-1]
         r = self.s.get(url, stream=True)
@@ -82,6 +89,7 @@ class ESTUpload:
         f.close()
         return
 
+    # returns the lecture ids of the logged in person
     def get_lecture_ids(self):
         ids = []
         for a in self.parse_html_id(self.s.get(self.base_url).text, 'estContent').find_all_next("a"):
@@ -90,29 +98,48 @@ class ESTUpload:
                 ids.append(a.next.strip())
         return list(OrderedDict.fromkeys(ids))
 
+    # returns the current est version
     def get_est_version(self):
         try:
             return self.parse_html_id(self.s.get(self.base_url).text, 'footermenu').find_next("li").text
         except requests.exceptions.ConnectionError:
             return '-1'
 
+    # returns True if the current est version is supported
     def check_est_version(self):
         est_version = self.get_est_version()
         return True if __est_version__ in est_version else est_version
 
+    # returns the name of the group submission partner
     def get_submission_with(self, group_submission_code, lecture_id):
-        return self.parse_html_text(self.s.get(self.base_url + '/submissiongroupdynamic.html?lectureId=' + str(lecture_id) +
-                                               '&action=submit&tab=overview')
-                                    .text, group_submission_code, "span").previous_element
+        return self.parse_html_text(self.s.get(self.base_url + '/submissiongroupdynamic.html?lectureId='
+                                               + str(lecture_id) + '&action=submit&tab=overview').text,
+                                    group_submission_code, "span").previous_element[:-2].strip()
 
-    def parse_html_id(self, html, id):
-        soup = BeautifulSoup(html)
-        return soup.find(id=id)
+    # returns the name of the group submission partner
+    def get_group_submission_code(self, file_name, lecture_id):
+        element = self.parse_html_text(self.s.get(self.base_url + '/submissiongroupdynamic.html?lectureId='
+                                            + str(lecture_id) + '&action=submit&tab=overview').text, file_name, 'td')
+        if element is None:
+            return ''
+        while not 'submissionGroupDynamicCode' in str(element):
+            if not element.next_element is None:
+                element = element.next_element
+            else:
+                return ''
+        return BeautifulSoup(str(element)).find('span', class_='submissionGroupDynamicCode').next_element
 
-    def parse_html_text(self, html, text, type):
+    @staticmethod
+    def parse_html_id(html, html_id):
         soup = BeautifulSoup(html)
-        return soup.find(type, text=text)
+        return soup.find(id=html_id)
 
-    def parse_html_find_all(self, html, type):
+    @staticmethod
+    def parse_html_text(html, text, html_type):
         soup = BeautifulSoup(html)
-        return soup.find_all(type)
+        return soup.find(html_type, text=text)
+
+    @staticmethod
+    def parse_html_find_all(html, html_type):
+        soup = BeautifulSoup(html)
+        return soup.find_all(html_type)

--- a/libest.py
+++ b/libest.py
@@ -2,7 +2,7 @@
 
 __author__ = 'jneureuther'
 __license__ = 'CC BY-SA 4.0'
-__version__ = '1.0'
+__version__ = '1.1.0'
 __est_version__ = 'Version 2.0.2384'
 
 import filecmp

--- a/libest.py
+++ b/libest.py
@@ -12,7 +12,7 @@ import magic
 from collections import OrderedDict
 
 
-class ESTUpload:
+class libest:
 
     def __init__(self):
         self.s = requests.session()

--- a/libest.py
+++ b/libest.py
@@ -39,7 +39,7 @@ class libest:
             return est_file_id_tag['for']
 
     # submits a file to est
-    def submit_file(self, name, path, lecture_id, submission_member_code):
+    def submit_file(self, name, path, lecture_id, submission_member_code=""):
         est_file_id = self.search_file(name, lecture_id)
         if est_file_id is 2:
             return 2
@@ -50,7 +50,8 @@ class libest:
 
         loc_file = [(est_file_id, (name, open(path, 'rb'), mime_type))]
         params = {'upload': 'upload', 'lectureId': str(lecture_id),
-                  'submitterCode_' + est_file_id[:4]: submission_member_code, 'action': 'submit', 'tab': 'upload'}
+                  'submitterCode_' + est_file_id[:4]: submission_member_code,
+                  'action': 'submit', 'tab': 'upload'}
         est_error = self.parse_html_id(self.s.post(self.base_url + '/encodingchecker.html', files=loc_file, data=params)
                                        .text, 'estError')
         if est_error is None:

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     author_email='dev@jneureuther.de',
     description='Library to communicate with Exercise Submission Tool (https://est.informatik.uni-erlangen.de)',
     long_description=long_description,
-    install_requires=['requests', 'python-magic', 'beautifulsoup4']
+    install_requires=['requests==2.3.0', 'python-magic', 'beautifulsoup4']
 )

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='est_upload',
+    name='libest',
     version='1.0.4',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    url='https://github.com/jneureuther/est_upload',
+    url='https://github.com/jneureuther/libest',
     license='CC BY-SA 4.0',
     author='Julian Neureuther',
     author_email='dev@jneureuther.de',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='libest',
-    version='1.0.4',
+    version='1.1.0',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     url='https://github.com/jneureuther/libest',
     license='CC BY-SA 4.0',


### PR DESCRIPTION
... to [jneureuther/est](https://github.com/jneureuther/est) in README

parsing numbers to string: I got errors, when `lecture_id` was a number because it should be a string
install requests 2.3.0: pip from the ubuntu package needs request 2.3.0. If you install the latest requests, pip won't work anymore.
added link to [jneureuther/est](https://github.com/jneureuther/est): When I searched [jneureuther/est](https://github.com/jneureuther/est), I only found [jneureuther/est_upload](https://github.com/jneureuther/est_upload)...
